### PR TITLE
Fix reuploading in flip editor

### DIFF
--- a/renderer/screens/flips/components/flip-editor.js
+++ b/renderer/screens/flips/components/flip-editor.js
@@ -209,6 +209,7 @@ function FlipEditor({idx = 0, src, visible, onChange, onChanging}) {
       setInsertImageMode(0)
     })
     reader.readAsDataURL(file)
+    e.target.value = ''
   }
 
   // Google search handling


### PR DESCRIPTION
In the flip editor, if you use the "Select file" button to upload a file and then try to upload the same file again (after editing it in external image editor, for example), the image would not upload the second time, even if you press the "Clear" button. This is because Chromium doesn't fire the `change` event of the file input element if the file path didn't change.
Resetting the value of the file input at the end of the file upload handler fixes this.