### PR TITLE
Fix flip creation date format

### DIFF
--- a/renderer/screens/flips/components.js
+++ b/renderer/screens/flips/components.js
@@ -116,7 +116,7 @@ export function FlipCard({flipService, onDelete}) {
               : t('Missing keywords')}
           </FlipCardTitle>
           <FlipCardSubtitle>
-            {dayjs(createdAt).format('d.MM.YYYY, H:mm')}
+            {dayjs(createdAt).format('D.MM.YYYY, H:mm')}
           </FlipCardSubtitle>
         </Box>
         {isActionable && (


### PR DESCRIPTION
Flip creation dates are being displayed incorrectly due to a typo in the date format string.