### PR TITLE
Fix copy method of text fileds

### DIFF
--- a/renderer/shared/hooks/use-clipboard.js
+++ b/renderer/shared/hooks/use-clipboard.js
@@ -1,18 +1,5 @@
 import React from 'react'
 
-function copyText(text) {
-  const tempInput = document.createElement('input')
-  tempInput.type = 'text'
-  tempInput.value = text
-
-  document.body.appendChild(tempInput)
-
-  tempInput.select()
-  document.execCommand('copy')
-
-  document.body.removeChild(tempInput)
-}
-
 function useClipboard() {
   const [value, setValue] = React.useState()
   const [error, setError] = React.useState()
@@ -22,7 +9,7 @@ function useClipboard() {
       throw new Error(`You must copy a string, not ${typeof text}`)
     }
     try {
-      copyText(text)
+      navigator.clipboard.writeText(text)
       setValue(text)
     } catch ({message}) {
       setError(message)


### PR DESCRIPTION
Behavior of `copyText` function wasn't consistent, it wasn't working for some fields. Replacing that function with a call to the clipboard API fixes that. Tested on Linux and Windows 10.

Fixes #408