### PR TITLE
Allow terminating unactivated invites

### DIFF
--- a/renderer/screens/contacts/components/invite-details.js
+++ b/renderer/screens/contacts/components/invite-details.js
@@ -80,7 +80,7 @@ function InviteDetails({dbkey, onClose, onSelect}) {
             })
           }}
           onKill={
-            canKill
+            canKill && !mining && !terminating
               ? () => {
                   setShowKillInviteForm(true)
                 }

--- a/renderer/shared/providers/invite-context.js
+++ b/renderer/shared/providers/invite-context.js
@@ -8,7 +8,11 @@ import {useIdentityState, IdentityStatus} from './identity-context'
 
 const db = global.invitesDb || {}
 
-const killableIdentities = [IdentityStatus.Newbie, IdentityStatus.Candidate]
+const killableIdentities = [
+  IdentityStatus.Newbie,
+  IdentityStatus.Candidate,
+  IdentityStatus.Invite,
+]
 
 const InviteStateContext = React.createContext()
 const InviteDispatchContext = React.createContext()
@@ -76,8 +80,8 @@ function InviteProvider({children}) {
         const isNewInviteActivated = !!invitee
 
         const canKill =
-          !!invitee &&
           !!invitedIdentity &&
+          (!!invitee || invitedIdentity.state === IdentityStatus.Invite) &&
           killableIdentities.includes(invitedIdentity.state)
 
         const isMining =


### PR DESCRIPTION
The node allows identities to terminate invites that have not been activated yet, so it makes sense to allow this in the client.

This is far from the prettiest solution, but it's the best I could come up with. The only problem is this change enables the terminate button even if the contact was given another unactivated invitation from someone else. But that's a pretty rare case.

Fixes #464 